### PR TITLE
Split code between two boards, communicating with esp-now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode/ipch
 
 //Ignore WiFi credentials file required for connecting to a network
+src/*/Credentials.cpp
 src/*/Credentials.h
 
 //Ignore custom test files 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,61 @@
-
 # 🦎 Tank Control System
 
 ## Overview
+
 The Tank Control System is a versatile, extensible platform designed to manage and automate environmental conditions for animal enclosures—originally tailored for lizard habitats 🦎, but easily adaptable to a wide range of applications such as aquariums 🐠, terrariums 🌱, and smart home projects 🏠.
 
 ## ✨ Key Features
+
 - **🌡️ Sensor Integration:** Supports temperature, humidity, and other environmental sensors for real-time monitoring.
 - **📷 Camera Integration:** Captures and streams live video from inside the tank, viewable via a web interface from anywhere (WAN support).
 - **🌐 Web-Based Control:** Provides a web page for remote monitoring and control of tank devices (lights, heat lamps, etc.).
+- **🔥 Mountable IR Heat Sensor:** Many existing temperature sensors fail to accurately capture the surface temperature of the basking spot. A mountable IR sensor solves that issue - it just needs line of sight to the surface.
 - **⏰ Time-of-Day & Temperature Automation:** Automatically controls devices based on user-defined schedules and temperature thresholds.
 - **🧩 Extensible Device Management:** Easily add or modify devices and sensors for different species or use cases.
 
-## 🚀 Planned Features
+## 🏗️ In Progress
+
 - **🌦️ Weather Data Integration:** Match tank conditions to the native environment of the animal by pulling real-time weather data from their natural habitat. This includes temperature/humidity control and simulated sunrise/sunset and light levels throughout the day.
+
+## 🚀 Planned Features
+
 - **🤖 AI Computer Vision:** Integrate AI-based image analysis to detect key events (e.g., animal activity, feeding, abnormal behavior) and send notifications or alerts.
 - **💡 Light Sequencing & Intensity Control:** Create a custom order and timing in which lights should turn on/off, and set intensities of the included LED strip for different times of day.
-- **🔥 Mountable IR Heat Sensor & Multi Sensor Control:** Many existing temperature sensors fail to accurately capture the surface temperature of the basking spot. A mountable IR sensor solves that issue - it just needs line of sight to the surface. Additionally, multi sensor control support lets users maintain hot and cold side temperatures.
+- **🌡️ Multi Sensor Control:** Multi sensor control will allow users to define more complex rules on how devices should behave.
+- **📊 Sensor & Event Logging:** Recorded sensor data (temperature, humidity, etc.) and key events (including camera-detected events) for historical analysis. And a camera and log lookback mode to review past conditions and events in the tank, helping with troubleshooting, animal health monitoring, and behavior analysis.
 
 ## 🛠️ Example Use Cases
+
 - 🦎 Lizard/reptile enclosures with precise day/night and temperature cycles
 - 🐟 Aquarium automation (lighting, feeding, water quality monitoring)
 - 🏠 Smart home environmental control
 
 ## 🚦 Getting Started
+
 1. **🔌 Hardware:**
    - ESP32-based controller (e.g., M5Stamp C3)
-   - Supported sensors (DHT11, etc.)
+   - Supported sensors (DHT11, AHT20, MLX90614 etc.)
    - Camera module (OV2640 or similar)
-   - Relays for device control (lights, heat lamps)
+   - Relays for external device control (e.g. turn lamps on/off)
 2. **💻 Software:**
    - PlatformIO/Arduino framework
    - Configure Wi-Fi and Firebase credentials in `src/config/Credentials.h`
    - Build and upload the firmware
-   - Firebase RealtimeDatabase needed for LAN control and stream viewing, for WAN you need to create a Firebase Web App.
+   - Firebase RealtimeDatabase needed for LAN control and stream viewing, for WAN you need to create a Firebase Web App. I've done everything on the free tier!
 3. **🌍 Web Interface:**
    - For LAN: Instruction coming soon!
    - For WAN: Instruction coming soon!
 
 ## 🧩 Extending the System
+
 - ➕ Add new sensors or devices by creating new classes in the `src/devices/` or `src/sensors/` directories
 - 🛠️ Modify automation logic in `main.cpp` or device classes
 - 🤝 Integrate additional APIs or AI modules as needed
 
 ## 🤝 Contributing
+
 Contributions are welcome! Please open issues or submit pull requests for new features, bug fixes, or documentation improvements.
 
 ---
 
-*This project is under active development. Stay tuned for more features and improvements!* 🚧
+_This project is under active development. Stay tuned for more features and improvements!_ 🚧

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,9 +17,11 @@ build_src_filter =
     -<camera_board_main.cpp>
 ; Uncomment the following lines (and comment framework=arduino) to enable OTA upload, default is serial upload
 ; upload_protocol = espota
-; upload_port = YOUR_BOARD_IP_HERE
+; upload_port = YOUR_MAIN_BOARD_IP_ADDRESS
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17
+; Change to your serial port, or remove to use default
+monitor_port = COM6
 monitor_speed = 115200
 lib_deps = 
 	adafruit/Adafruit Unified Sensor@^1.1.15
@@ -36,52 +38,17 @@ board = esp32cam
 framework = arduino
 ; Uncomment the following lines (and comment framework=arduino) to enable OTA upload, default is serial upload
 ; upload_protocol = espota
-; upload_port = YOUR_BOARD_IP_HERE
+; upload_port = YOUR_CAMERA_BOARD_IP_ADDRESS
 build_src_filter = 
     -<*>
     +<camera_board_main.cpp>
-    +<utils/WiFiUtil.h>
-    +<utils/WiFiUtil.cpp>
+    +<utils/WiFiHelper.h>
+    +<utils/WiFiHelper.cpp>
     +<config/Credentials.h>
     +<config/Credentials.cpp>
     +<utils/MessageTypes.h>
 monitor_speed = 115200
+; Change to your serial port, or remove to use default
+monitor_port = COM4
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17
-
-
-; Below are some example environments for testing individual components
-[env:camera_test]
-platform = espressif32
-board = esp32cam
-; board = esp32-c3-devkitm-1
-framework = arduino
-build_src_filter = +<camera_test.cpp>
-monitor_speed = 115200
-lib_deps =
-    arducam/ArduCAM
-build_unflags = -std=gnu++11
-build_flags = -std=gnu++17
-
-[env:arduino-uno]
-platform = atmelavr
-board = uno
-framework = arduino
-lib_deps = 
-  adafruit/Adafruit AHTX0
-build_src_filter = +<test_uno.cpp>
-monitor_speed = 115200
-
-[env:simple_test]
-platform = espressif32
-board = esp32cam
-framework = arduino
-; upload_protocol = espota
-; upload_port = 10.0.0.4
-build_src_filter = +<simple_test.cpp>
-monitor_speed = 115200
-build_unflags = -std=gnu++11
-build_flags = -std=gnu++17
-; ; Enable PSRAM if your board supports it
-; board_build.psram = true
-; board_build.flash_size = 4MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,10 +8,13 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:m5stamp-c3]
+[env:main-board]
 platform = espressif32
 board = esp32-c3-devkitm-1
 framework = arduino 
+build_src_filter = 
+    +<*>
+    -<camera_board_main.cpp>
 ; Uncomment the following lines (and comment framework=arduino) to enable OTA upload, default is serial upload
 ; upload_protocol = espota
 ; upload_port = YOUR_BOARD_IP_HERE
@@ -27,27 +30,27 @@ lib_deps =
 	adafruit/Adafruit MLX90614 Library@^2.1.5
 	adafruit/Adafruit AHTX0
 
-[env:esp32cam]
+[env:camera-board]
 platform = espressif32
 board = esp32cam
 framework = arduino
+; Uncomment the following lines (and comment framework=arduino) to enable OTA upload, default is serial upload
+; upload_protocol = espota
+; upload_port = YOUR_BOARD_IP_HERE
 build_src_filter = 
     -<*>
     +<camera_board_main.cpp>
-    +<devices/CameraDevice.cpp>
-    +<devices/Device.h>
     +<utils/WiFiUtil.h>
 monitor_speed = 115200
-lib_deps =
-    arducam/ArduCAM
-	bblanchon/ArduinoJson@^7.4.2
-
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17
 
+
+; Below are some example environments for testing individual components
 [env:camera_test]
 platform = espressif32
-board = esp32-c3-devkitm-1
+board = esp32cam
+; board = esp32-c3-devkitm-1
 framework = arduino
 build_src_filter = +<camera_test.cpp>
 monitor_speed = 115200
@@ -65,3 +68,16 @@ lib_deps =
 build_src_filter = +<test_uno.cpp>
 monitor_speed = 115200
 
+[env:simple_test]
+platform = espressif32
+board = esp32cam
+framework = arduino
+; upload_protocol = espota
+; upload_port = 10.0.0.4
+build_src_filter = +<simple_test.cpp>
+monitor_speed = 115200
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17
+; ; Enable PSRAM if your board supports it
+; board_build.psram = true
+; board_build.flash_size = 4MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,10 @@ build_src_filter =
     -<*>
     +<camera_board_main.cpp>
     +<utils/WiFiUtil.h>
+    +<utils/WiFiUtil.cpp>
+    +<config/Credentials.h>
+    +<config/Credentials.cpp>
+    +<utils/MessageTypes.h>
 monitor_speed = 115200
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,23 @@ lib_deps =
 	adafruit/Adafruit MLX90614 Library@^2.1.5
 	adafruit/Adafruit AHTX0
 
+[env:esp32cam]
+platform = espressif32
+board = esp32cam
+framework = arduino
+build_src_filter = 
+    -<*>
+    +<camera_board_main.cpp>
+    +<devices/CameraDevice.cpp>
+    +<devices/Device.h>
+    +<utils/WiFiUtil.h>
+monitor_speed = 115200
+lib_deps =
+    arducam/ArduCAM
+	bblanchon/ArduinoJson@^7.4.2
+
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17
 
 [env:camera_test]
 platform = espressif32

--- a/src/camera_board_main.cpp
+++ b/src/camera_board_main.cpp
@@ -1,0 +1,65 @@
+#include "devices/CameraDevice.h"
+#include "esp_log.h"
+#include <Arduino.h>
+#include <config/Credentials.h>
+#include <esp_now.h>
+#include <utils/WiFiUtil.h>
+
+//**************
+// This implentation uses the M5Stamp C3 board with the Arduino framework.
+// Certain pins selections assume defaults for the M5Stamp C3 board.
+// If you are using a different board, please adjust the pin numbers
+// accordingly.
+//***** */
+#define SDA_PIN 8
+#define SCL_PIN 9
+
+// Camera frame rate for streaming
+constexpr int8_t framesPerSecond = 5;
+// Task priority for camera capture task
+constexpr int8_t cameraTaskPriority = 3;
+uint8_t camPins[6] = {5, 4,       7,
+                      6, SDA_PIN, SCL_PIN}; // CS, SCK, MISO, MOSI, SDA, SCL
+CameraDevice camera("camera", camPins, CameraDevice::Resolution::QVGA,
+                    framesPerSecond, cameraTaskPriority);
+
+// callback function that will be executed when data is received from main board
+struct_message mainBoardData;
+void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+  memcpy(&mainBoardData, incomingData, sizeof(mainBoardData));
+  Serial.print("Bytes received: ");
+  Serial.println(len);
+  Serial.print("Message: ");
+  Serial.println(mainBoardData.message);
+  Serial.print("Camera Action: ");
+  Serial.println(mainBoardData.camera_action);
+
+  if (mainBoardData.camera_action == 1) {
+    // Turn on camera
+    camera.turnOn();
+  } else if (mainBoardData.camera_action == 0) {
+    // Turn off camera
+    camera.turnOff();
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  // Enable for detailed debug output (for when the gremlins strike)
+  // Serial.setDebugOutput(true);
+  // esp_log_level_set("*", ESP_LOG_VERBOSE);
+  camera.begin();
+  // True to setup OTA updates, false to skip
+  WiFiUtil::connectAndSyncTime(true);
+  WiFiUtil::setupEspNow(true, onDataRecv);
+  delay(1000); // Allow time for devices to initialize
+  Serial.println("Initialization complete.!");
+}
+
+void loop() {
+
+  // Handle OTA updates
+  ArduinoOTA.handle();
+  // Maintain WiFi connection
+  WiFiUtil::maintain();
+}

--- a/src/camera_board_main.cpp
+++ b/src/camera_board_main.cpp
@@ -3,7 +3,7 @@
 #include <Arduino.h>
 #include <WiFiUdp.h>
 #include <esp_now.h>
-#include <utils/WiFiUtil.h>
+#include <utils/WiFiHelper.h>
 
 //**************
 // This implentation uses the esp32-cam dev board with the espressif +
@@ -15,7 +15,7 @@ constexpr int TARGET_FPS = 5; // Adjust this value to change FPS
 constexpr unsigned long FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
 const size_t CHUNK_SIZE = 1024; // Size of each UDP packet chunk
 
-WiFiUtil wifi;
+WiFiHelper wifi;
 WiFiUDP udp;
 unsigned long lastFrameTime = 0; // Add this variable to track timing
 bool shouldBeStreaming = false;

--- a/src/camera_board_main.cpp
+++ b/src/camera_board_main.cpp
@@ -1,7 +1,6 @@
 #include "devices/CameraDevice.h"
 #include "esp_log.h"
 #include <Arduino.h>
-#include <config/Credentials.h>
 #include <esp_now.h>
 #include <utils/WiFiUtil.h>
 
@@ -56,10 +55,16 @@ void setup() {
   Serial.println("Initialization complete.!");
 }
 
+static unsigned long lastPrint = 0;
+
 void loop() {
 
   // Handle OTA updates
   ArduinoOTA.handle();
   // Maintain WiFi connection
   WiFiUtil::maintain();
+  if (millis() - lastPrint >= 1000) {
+    Serial.println("I'm alive");
+    lastPrint = millis();
+  }
 }

--- a/src/camera_board_main.cpp
+++ b/src/camera_board_main.cpp
@@ -15,6 +15,7 @@ constexpr int TARGET_FPS = 5; // Adjust this value to change FPS
 constexpr unsigned long FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
 const size_t CHUNK_SIZE = 1024; // Size of each UDP packet chunk
 
+WiFiUtil wifi;
 WiFiUDP udp;
 unsigned long lastFrameTime = 0; // Add this variable to track timing
 bool shouldBeStreaming = false;
@@ -67,8 +68,8 @@ void setup() {
   // Serial.setDebugOutput(true);
   // esp_log_level_set("*", ESP_LOG_VERBOSE);
   // True to setup OTA updates, false to skip
-  WiFiUtil::connectAndSyncTime(true);
-  WiFiUtil::setupEspNow(true, cameraBoardOnDataRecv);
+  wifi.connectAndSyncTime(true);
+  wifi.setupEspNow(true, cameraBoardOnDataRecv);
 
   camera_config_t config;
   config.ledc_channel = LEDC_CHANNEL_0;
@@ -85,8 +86,8 @@ void setup() {
   config.pin_pclk = 22;
   config.pin_vsync = 25;
   config.pin_href = 23;
-  config.pin_sscb_sda = 26;
-  config.pin_sscb_scl = 27;
+  config.pin_sccb_sda = 26; // Changed from pin_sscb_sda
+  config.pin_sccb_scl = 27; // Changed from pin_sscb_scl
   config.pin_pwdn = 32;
   config.pin_reset = -1;
   config.xclk_freq_hz = 20000000;
@@ -110,7 +111,7 @@ void loop() {
   // Handle OTA updates
   ArduinoOTA.handle();
   // Maintain WiFi connection
-  WiFiUtil::maintain();
+  wifi.maintain();
 
   if (!shouldBeStreaming) {
     return; // Not streaming, skip the rest of the loop

--- a/src/config/Credentials.h.template
+++ b/src/config/Credentials.h.template
@@ -1,0 +1,28 @@
+//To use this:
+// Copy Credentials.h.template to Credentials.h
+// Add your actual MAC addresses in Credentials.h
+// Git will ignore your local Credentials.h file
+
+#pragma once
+
+#define WIFI_SSID "YOUR_SSID"
+#define WIFI_PASSWORD "YOUR_PASSWORD"
+
+#define VIDEO_WEB_SERVER_IP "YOUR_LAPTOP_IP"
+#define VIDEO_WEB_SERVER_PORT 5005
+
+#define MAIN_BOARD_IP "YOUR_MAIN_BOARD_IP"
+#define CAMERA_BOARD_IP "YOUR_CAMERA_BOARD_IP"
+
+#define FIREBASE_WEB_API_KEY "YOUR_FIREBASE_WEB_API_KEY"
+#define FIREBASE_USER_EMAIL "YOUR_FIREBASE_EMAIL"
+#define FIREBASE_USER_PASSWORD "YOUR_FIREBASE_PASSWORD"
+#define FIREBASE_DATABASE_URL "YOUR_FIREBASE_DATABASE_URL"
+
+// Board MAC addresses (replace with your actual MAC addresses)
+const uint8_t MAIN_BOARD_MAC_ADDRESS[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+const uint8_t CAMERA_BOARD_MAC_ADDRESS[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+#if MAIN_BOARD_MAC_ADDRESS[0] == 0x00 || CAMERA_BOARD_MAC_ADDRESS[0] == 0x00
+#error "Please copy Credentials.h.template to Credentials.h and set your MAC addresses"
+#endif

--- a/src/config/Credentials.h.template
+++ b/src/config/Credentials.h.template
@@ -11,18 +11,11 @@
 #define VIDEO_WEB_SERVER_IP "YOUR_LAPTOP_IP"
 #define VIDEO_WEB_SERVER_PORT 5005
 
-#define MAIN_BOARD_IP "YOUR_MAIN_BOARD_IP"
-#define CAMERA_BOARD_IP "YOUR_CAMERA_BOARD_IP"
-
 #define FIREBASE_WEB_API_KEY "YOUR_FIREBASE_WEB_API_KEY"
 #define FIREBASE_USER_EMAIL "YOUR_FIREBASE_EMAIL"
 #define FIREBASE_USER_PASSWORD "YOUR_FIREBASE_PASSWORD"
 #define FIREBASE_DATABASE_URL "YOUR_FIREBASE_DATABASE_URL"
 
-// Board MAC addresses (replace with your actual MAC addresses)
+// Board MAC addresses (replace with your actual MAC addresses) but move to cpp file
 const uint8_t MAIN_BOARD_MAC_ADDRESS[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 const uint8_t CAMERA_BOARD_MAC_ADDRESS[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-
-#if MAIN_BOARD_MAC_ADDRESS[0] == 0x00 || CAMERA_BOARD_MAC_ADDRESS[0] == 0x00
-#error "Please copy Credentials.h.template to Credentials.h and set your MAC addresses"
-#endif

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,2 +1,5 @@
 # This folder is here to store the sensitive information kept behind global variables
+
 # For compilation to be successfull there needs to be a Credentials.h file here
+
+# View Credentails.h.template for details on what to put in the Credentials.h file.

--- a/src/devices/CameraDevice.cpp
+++ b/src/devices/CameraDevice.cpp
@@ -154,8 +154,12 @@ void CameraDevice::startStreamTaskAsync() {
     return;
   }
   Serial.println("Starting async stream task 🎥");
-  // Use priority 16 for camera task - max priority is configMAX_PRIORITIES, 18
-  // and above is usually system critical tasks
+  // TODO This is not best way of using FreeRTOS tasks but works for now, should
+  // create in main loop
+  // and use vTaskStartScheduler() to start all tasks -> This stream task should
+  // be blocked until user sends devices command. Use priority 16 for camera
+  // task - max priority is configMAX_PRIORITIES, 18 and above is usually system
+  // critical tasks
   xTaskCreate(
       [](void *params) {
         static_cast<CameraDevice *>(params)->handleStreamTaskAsync(params);

--- a/src/devices/CameraDevice.cpp
+++ b/src/devices/CameraDevice.cpp
@@ -1,79 +1,40 @@
 #include "CameraDevice.h"
 
-// Pin order: {CS, SCK, MISO, MOSI, SDA, SCL}
-CameraDevice::CameraDevice(const std::string &name, const uint8_t pins[6],
-                           Resolution res, int8_t fps,
-                           int8_t cameraTaskPriority)
-    : Device(name), csPin(pins[0]), sckPin(pins[1]), misoPin(pins[2]),
-      mosiPin(pins[3]), sdaPin(pins[4]), sclPin(pins[5]), resolution(res),
-      fps(fps), cameraTaskPriority(cameraTaskPriority),
-      camera(OV2640, pins[0]) {
-  xPeriod = pdMS_TO_TICKS((1000 / (fps)));
+CameraDevice::CameraDevice(const std::string &name, const uint8_t macAddress[6])
+    : Device(name) {
+  memcpy(this->cameraBoardMacAddress, macAddress, 6);
 }
 
-void CameraDevice::begin() {
-  Serial.println("Camera begin: setting pinMode");
-  pinMode(csPin, OUTPUT);
+const struct_message CameraDevice::CAMERA_ON_MESSAGE = {
+    "CAMERA", // message
+    1         // camera_action, 1 for ON
+};
 
-  Wire.begin(sdaPin, sclPin);
+const struct_message CameraDevice::CAMERA_OFF_MESSAGE = {
+    "CAMERA", // message
+    0         // camera_action, 0 for OFF
+};
 
-  delay(10);
-
-  SPI.begin(sckPin, misoPin, mosiPin, csPin);
-  // Reset the CPLD
-  camera.write_reg(0x07, 0x80);
-  delay(100);
-  camera.write_reg(0x07, 0x00);
-  delay(100);
-
-  // Check if the ArduCAM SPI bus is OK
-  camera.write_reg(ARDUCHIP_TEST1, 0x55);
-  uint8_t temp = camera.read_reg(ARDUCHIP_TEST1);
-  if (temp != 0x55) {
-    Serial.println(F("ACK CMD SPI interface Error! END"));
-    delay(1000);
-  } else {
-    Serial.println(F("ACK CMD SPI interface OK. END"));
-  }
-
-  camera.CS_HIGH();
-  camera.set_format(JPEG);
-
-  Wire.beginTransmission(0x30); // OV2640 default
-  if (Wire.endTransmission() != 0) {
-    Serial.println("ERROR: Camera I2C not found. Check SDA/SCL wiring.");
-    return;
-  }
-
-  camera.InitCAM();
-
-  camera.clear_fifo_flag();
-  setResolution(resolution);
-
-  this->setState(true);
-  Serial.println("📸 Camera initialized 📸");
-}
-
-void CameraDevice::update() {
-  // No periodic updates needed
-}
-
+// State will be set by onDataSent callback in main.cpp -> This guarantees
+// camera state represents true state of camera board.
 void CameraDevice::turnOn() {
-  // Setting state first to make sure camera passes on check
-  this->setState(true);
+  esp_err_t result =
+      esp_now_send(this->cameraBoardMacAddress, (uint8_t *)&CAMERA_ON_MESSAGE,
+                   sizeof(CAMERA_ON_MESSAGE));
 
-  // Only start stream if Task doesnt exist already
-  if (handleStreamTask == nullptr) {
-    startStreamTaskAsync();
+  if (result != ESP_OK) {
+    // TODO Document error state for publishing to firebase
+    Serial.println("Error sending camera command");
   }
 }
 void CameraDevice::turnOff() {
-  this->setState(false);
+  esp_err_t result =
+      esp_now_send(this->cameraBoardMacAddress, (uint8_t *)&CAMERA_OFF_MESSAGE,
+                   sizeof(CAMERA_OFF_MESSAGE));
 
-  Serial.println("Turning off the Stream!");
-  if (handleStreamTask != nullptr) {
-    vTaskDelete(handleStreamTask);
-    handleStreamTask = nullptr;
+  if (result != ESP_OK) {
+    // TODO Document error state for publishing to firebase
+    Serial.println("Error sending camera command");
   }
 }
 
@@ -90,100 +51,4 @@ void CameraDevice::applyState(JsonVariantConst desired) {
 
 void CameraDevice::reportState(JsonDocument &doc) {
   doc["state"] = this->isOn();
-}
-
-void CameraDevice::handleStreamTaskAsync(void *param) {
-  // Set last wake time for accurate periodic delay
-  xLastWakeTime = xTaskGetTickCount();
-  while (true) {
-
-    if (!capturing) {
-      camera.flush_fifo();
-      camera.clear_fifo_flag();
-      camera.start_capture();
-      capturing = true;
-      imageCorrupted = false;
-      frameReady = false;
-      jpegBufferLen = 0;
-    }
-
-    if (camera.get_bit(
-            ARDUCHIP_TRIG,
-            CAP_DONE_MASK)) { // TODO consider moving this to isFrameReady()
-                              // function and removing frameReady bool
-
-      frameReady = true;
-      jpegBufferLen = camera.read_fifo_length();
-
-      if (jpegBufferLen == 0 || jpegBufferLen > MAX_BUFFER_SIZE) {
-        imageCorrupted = true;
-        capturing = false;
-        Serial.println("ERROR: Image corrupted during stream");
-        continue;
-      }
-      imageCorrupted = false;
-      capturing = false;
-      camera.CS_LOW();
-      camera.set_fifo_burst();
-      const size_t CHUNK_SIZE = 1024;
-      size_t bufferLen = jpegBufferLen;
-      while (bufferLen > 0) {
-        size_t toRead = min(CHUNK_SIZE, bufferLen);
-        SPI.transfer(jpegBuffer, toRead);
-        udp.beginPacket(GANGLYPUMA22_LAPTOP_IP, GANGLYPUMA22_LAPTOP_PORT);
-        udp.write(jpegBuffer, toRead);
-        udp.endPacket();
-        bufferLen -= toRead;
-      }
-
-      camera.CS_HIGH();
-
-      // Delay inside the capture section so that it only delays once for the
-      // capture + send timing. If in main while loop it delays multiple times
-      BaseType_t wasDelayed = xTaskDelayUntil(&xLastWakeTime, xPeriod);
-    }
-  }
-  Serial.print("ERROR: Issue during camera capture process... Ending Stream!");
-  vTaskDelete(NULL);
-  handleStreamTask = nullptr;
-}
-
-void CameraDevice::startStreamTaskAsync() {
-  if (!this->isOn()) {
-    Serial.println("ERROR: Camera not initialized - cannot start stream task");
-    return;
-  }
-  Serial.println("Starting async stream task 🎥");
-  // TODO This is not best way of using FreeRTOS tasks but works for now, should
-  // create in main loop
-  // and use vTaskStartScheduler() to start all tasks -> This stream task should
-  // be blocked until user sends devices command. Use priority 16 for camera
-  // task - max priority is configMAX_PRIORITIES, 18 and above is usually system
-  // critical tasks
-  xTaskCreate(
-      [](void *params) {
-        static_cast<CameraDevice *>(params)->handleStreamTaskAsync(params);
-      },
-      "CameraCaptureTask", 4096, this, cameraTaskPriority, &handleStreamTask);
-}
-
-void CameraDevice::setResolution(Resolution res) {
-  resolution = res;
-  switch (res) {
-  case Resolution::QVGA:
-    camera.OV2640_set_JPEG_size(OV2640_320x240);
-    break;
-  case Resolution::VGA:
-    camera.OV2640_set_JPEG_size(OV2640_640x480);
-    break;
-  case Resolution::SVGA:
-    camera.OV2640_set_JPEG_size(OV2640_800x600);
-    break;
-  case Resolution::XGA:
-    camera.OV2640_set_JPEG_size(OV2640_1024x768);
-    break;
-  case Resolution::FULL:
-    camera.OV2640_set_JPEG_size(OV2640_1600x1200);
-    break;
-  }
 }

--- a/src/devices/CameraDevice.cpp
+++ b/src/devices/CameraDevice.cpp
@@ -6,15 +6,16 @@ CameraDevice::CameraDevice(
   // memcpy(this->cameraBoardMacAddress, macAddress, 6);
 }
 
-const struct_message CameraDevice::CAMERA_ON_MESSAGE = {
-    "CAMERA", // message
-    1         // camera_action, 1 for ON
-};
+void CameraDevice::setCameraMessage(String message, int camera_action,
+                                    int fps) {
 
-const struct_message CameraDevice::CAMERA_OFF_MESSAGE = {
-    "CAMERA", // message
-    0         // camera_action, 0 for OFF
-};
+  strncpy(this->cameraMessage.message, message.c_str(),
+          sizeof(this->cameraMessage.message) - 1);
+  this->cameraMessage.message[sizeof(this->cameraMessage.message) - 1] =
+      '\0'; // Ensure null-termination
+  this->cameraMessage.camera_action = camera_action;
+  this->cameraMessage.fps = fps;
+}
 
 // TODO Cleanest way to do this here would be to have a time check for last
 // retry and only retry every x seconds
@@ -37,10 +38,10 @@ void CameraDevice::update() {
   }
 }
 
-bool CameraDevice::attemptSend(const struct_message &message) {
+bool CameraDevice::attemptSend(const camera_message &message) {
   esp_err_t result =
       esp_now_send(CAMERA_BOARD_MAC_ADDRESS, (const uint8_t *)&message,
-                   sizeof(struct_message));
+                   sizeof(camera_message));
 
   if (result == ESP_OK) {
     return true;
@@ -51,10 +52,27 @@ bool CameraDevice::attemptSend(const struct_message &message) {
 
 // State will be set by onDataSent callback in main.cpp -> This guarantees
 // camera state represents true state of camera board.
-void CameraDevice::turnOn() { attemptSend(CAMERA_ON_MESSAGE); }
-void CameraDevice::turnOff() { attemptSend(CAMERA_OFF_MESSAGE); }
+void CameraDevice::turnOn() {
+  setCameraMessage("Camera On", 1, this->fps);
+  attemptSend(this->cameraMessage);
+}
+void CameraDevice::turnOff() {
+  setCameraMessage("Camera Off", 0, this->fps);
+  attemptSend(this->cameraMessage);
+}
 
 void CameraDevice::applyState(JsonVariantConst desired) {
+  // FPS needs to be set first since turnOn and turnOff use it
+  if (desired["fps"].is<JsonVariantConst>()) {
+    int newFps = desired["fps"].as<int>();
+    if (newFps > 0 && newFps <= 30) {
+      this->setFps(newFps);
+      setCameraMessage("Camera FPS", 2, this->fps);
+      attemptSend(this->cameraMessage);
+    } else {
+      Serial.println("Invalid FPS value received, must be between 1 and 30");
+    }
+  }
   if (desired["state"].is<JsonVariantConst>()) {
     this->shouldBeOnState = desired["state"].as<bool>();
     this->currentRetryCount = 0;
@@ -70,4 +88,5 @@ void CameraDevice::applyState(JsonVariantConst desired) {
 void CameraDevice::reportState(JsonDocument &doc) {
   doc["state"] = this->isOn();
   doc["error"] = this->hasError();
+  doc["fps"] = this->getFps();
 }

--- a/src/devices/CameraDevice.cpp
+++ b/src/devices/CameraDevice.cpp
@@ -16,30 +16,49 @@ const struct_message CameraDevice::CAMERA_OFF_MESSAGE = {
     0         // camera_action, 0 for OFF
 };
 
+// TODO Cleanest way to do this here would be to have a time check for last
+// retry and only retry every x seconds
+void CameraDevice::update() {
+  if (this->shouldBeOnState != this->isOn() &&
+      this->currentlySendingEspNowCommand &&
+      this->currentRetryCount < MAX_ESP_NOW_RETRIES) {
+    this->currentRetryCount++;
+    // Desired state differs from actual state, attempt to correct
+    if (this->shouldBeOnState) {
+      turnOn();
+    } else {
+      turnOff();
+    }
+  }
+
+  if (this->currentRetryCount >= MAX_ESP_NOW_RETRIES) {
+    this->currentlySendingEspNowCommand = false;
+    this->setErrorState(true);
+  }
+}
+
+bool CameraDevice::attemptSend(const struct_message &message) {
+  esp_err_t result =
+      esp_now_send(CAMERA_BOARD_MAC_ADDRESS, (const uint8_t *)&message,
+                   sizeof(struct_message));
+
+  if (result == ESP_OK) {
+    return true;
+  }
+
+  return false;
+}
+
 // State will be set by onDataSent callback in main.cpp -> This guarantees
 // camera state represents true state of camera board.
-void CameraDevice::turnOn() {
-  bool result = WiFiHelper::sendData(CAMERA_BOARD_MAC_ADDRESS,
-                                     (uint8_t *)&CAMERA_ON_MESSAGE);
-
-  if (!result) {
-    this->errorState = true;
-    Serial.println("Error sending camera command");
-  }
-}
-void CameraDevice::turnOff() {
-  bool result = WiFiHelper::sendData(CAMERA_BOARD_MAC_ADDRESS,
-                                     (uint8_t *)&CAMERA_OFF_MESSAGE);
-
-  if (!result) {
-    this->errorState = true;
-    Serial.println("Error sending camera command");
-  }
-}
+void CameraDevice::turnOn() { attemptSend(CAMERA_ON_MESSAGE); }
+void CameraDevice::turnOff() { attemptSend(CAMERA_OFF_MESSAGE); }
 
 void CameraDevice::applyState(JsonVariantConst desired) {
   if (desired["state"].is<JsonVariantConst>()) {
     this->shouldBeOnState = desired["state"].as<bool>();
+    this->currentRetryCount = 0;
+    this->currentlySendingEspNowCommand = true;
     if (this->shouldBeOnState) {
       turnOn();
     } else {

--- a/src/devices/CameraDevice.cpp
+++ b/src/devices/CameraDevice.cpp
@@ -1,8 +1,9 @@
 #include "CameraDevice.h"
 
-CameraDevice::CameraDevice(const std::string &name, const uint8_t macAddress[6])
+CameraDevice::CameraDevice(
+    const std::string &name) //, const uint8_t macAddress[6])
     : Device(name) {
-  memcpy(this->cameraBoardMacAddress, macAddress, 6);
+  // memcpy(this->cameraBoardMacAddress, macAddress, 6);
 }
 
 const struct_message CameraDevice::CAMERA_ON_MESSAGE = {
@@ -19,7 +20,7 @@ const struct_message CameraDevice::CAMERA_OFF_MESSAGE = {
 // camera state represents true state of camera board.
 void CameraDevice::turnOn() {
   esp_err_t result =
-      esp_now_send(this->cameraBoardMacAddress, (uint8_t *)&CAMERA_ON_MESSAGE,
+      esp_now_send(CAMERA_BOARD_MAC_ADDRESS, (uint8_t *)&CAMERA_ON_MESSAGE,
                    sizeof(CAMERA_ON_MESSAGE));
 
   if (result != ESP_OK) {
@@ -29,7 +30,7 @@ void CameraDevice::turnOn() {
 }
 void CameraDevice::turnOff() {
   esp_err_t result =
-      esp_now_send(this->cameraBoardMacAddress, (uint8_t *)&CAMERA_OFF_MESSAGE,
+      esp_now_send(CAMERA_BOARD_MAC_ADDRESS, (uint8_t *)&CAMERA_OFF_MESSAGE,
                    sizeof(CAMERA_OFF_MESSAGE));
 
   if (result != ESP_OK) {

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "../config/Credentials.h"
 #include "../utils/MessageTypes.h"
-#include "../utils/WiFiHelper.h"
 #include "Device.h"
+#include <esp_now.h>
 
 // Conflicting sensor_t definition between esp_camera and arduinojson
 #define sensor_t camera_sensor_t
@@ -18,7 +18,7 @@ class CameraDevice : public Device {
 public:
   CameraDevice(const std::string &name); //, const uint8_t macAddress[6]);
   void begin() override{};
-  void update() override{};
+  void update() override;
   // Using override calls to start and stop streams
   void turnOn() override;
   void turnOff() override;
@@ -36,4 +36,11 @@ private:
   // Define constant messages for on/off commands
   static const struct_message CAMERA_ON_MESSAGE;
   static const struct_message CAMERA_OFF_MESSAGE;
+
+  // ESP-NOW retry variables
+  bool currentlySendingEspNowCommand = false;
+  int currentRetryCount = 0;
+  static constexpr int MAX_ESP_NOW_RETRIES = 5;
+
+  bool attemptSend(const struct_message &message);
 };

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "../config/Credentials.h"
 #include "../utils/MessageTypes.h"
+#include "../utils/WiFiHelper.h"
 #include "Device.h"
 
+// Conflicting sensor_t definition between esp_camera and arduinojson
 #define sensor_t camera_sensor_t
 #include <esp_camera.h>
 #undef sensor_t
-#include <esp_now.h>
 
 // This class encompases the management of the camera device from a state and
 // communication perspective The actual camera board will run a separate
@@ -23,9 +24,15 @@ public:
   void turnOff() override;
   void reportState(JsonDocument &doc) override;
   void applyState(JsonVariantConst desired) override;
+  bool shouldBeOn() { return shouldBeOnState; }
+  void setErrorState(bool state) { errorState = state; }
+  bool hasError() { return errorState; }
 
 private:
-  // uint8_t cameraBoardMacAddress[6];
+  // Used to track desired state from Firebase database
+  bool shouldBeOnState = false;
+  // Used to track if there was an error sending command to camera board
+  bool errorState = false;
   // Define constant messages for on/off commands
   static const struct_message CAMERA_ON_MESSAGE;
   static const struct_message CAMERA_OFF_MESSAGE;

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "../utils/WiFiUtil.h" // Include WiFiUtil for struct_message definition
+#include "../utils/MessageTypes.h"
 #include "Device.h"
 #define sensor_t camera_sensor_t
 #include <esp_camera.h>

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -1,72 +1,31 @@
 #pragma once
 
-#include <Arduino.h>
-
+#include "../utils/WiFiUtil.h" // Include WiFiUtil for struct_message definition
 #include "Device.h"
-#include "memorysaver.h" // needed for OV2640 //THIS NEEDS TO BE SET IN ARDUCAM LIBRARY
-#include <ArduCAM.h>
+#define sensor_t camera_sensor_t
+#include <esp_camera.h>
+#undef sensor_t
+#include <esp_now.h>
 
-// Undefine ArduCAM's swap macro to prevent conflicts with std::swap
-#ifdef swap
-#undef swap
-#endif
-
-#include "../config/Credentials.h"
-#include <SPI.h>
-#include <WiFi.h>
-#include <WiFiUdp.h>
-#include <Wire.h>
-#include <algorithm>
+// This class encompases the management of the camera device from a state and
+// communication perspective The actual camera board will run a separate
+// firmware that receives commands from this class to start and stop streaming,
+// and sends frames back via ESP-NOW and see camera_board_main.cpp
 
 class CameraDevice : public Device {
 public:
-  enum class Resolution {
-    VGA, // default
-    QVGA,
-    SVGA,
-    XGA,
-    FULL
-  };
-
-  // Pin order: {CS, SCK, MISO, MOSI, SDA, SCL}
-  CameraDevice(const std::string &name, const uint8_t pins[6],
-               Resolution res = Resolution::VGA, int8_t fps = 5,
-               int8_t cameraTaskPriority = 8); // UDP priority 18
-
-  static constexpr size_t MAX_BUFFER_SIZE =
-      40 * 1024; // TODO Make this configurable
-
-  WiFiUDP udp;
-
-  void begin() override;
-  void update() override;
+  CameraDevice(const std::string &name, const uint8_t macAddress[6]);
+  void begin() override{};
+  void update() override{};
+  // Using override calls to start and stop streams
   void turnOn() override;
   void turnOff() override;
   void reportState(JsonDocument &doc) override;
   void applyState(JsonVariantConst desired) override;
-  void setResolution(Resolution res);
-  uint8_t *getJpegBuffer() { return jpegBuffer; }
-  size_t getJpegBufferLen() { return jpegBufferLen; }
-  bool isCapturing() const { return capturing; }
-  bool isFrameReady() const { return frameReady; }
-  void setFrameReady(bool ready) { frameReady = ready; }
-  bool isImageCorrupted() const { return imageCorrupted; }
-  void startStreamTaskAsync();
-  void handleStreamTaskAsync(void *params);
 
 private:
-  int8_t fps;
-  int8_t cameraTaskPriority;
-  const uint8_t csPin, sckPin, misoPin, mosiPin, sdaPin, sclPin;
-  bool camera_initialized;
-  Resolution resolution;
-  ArduCAM camera;
-  volatile bool capturing = false;
-  volatile bool frameReady = false;
-  volatile bool imageCorrupted = false;
-  uint8_t jpegBuffer[MAX_BUFFER_SIZE];
-  volatile size_t jpegBufferLen = 0;
-  TaskHandle_t handleStreamTask;
-  TickType_t xLastWakeTime;
-  TickType_t xPeriod;
+  uint8_t cameraBoardMacAddress[6];
+  // Define constant messages for on/off commands
+  static const struct_message CAMERA_ON_MESSAGE;
+  static const struct_message CAMERA_OFF_MESSAGE;
 };

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -27,20 +27,24 @@ public:
   bool shouldBeOn() { return shouldBeOnState; }
   void setErrorState(bool state) { errorState = state; }
   bool hasError() { return errorState; }
+  int getFps() { return fps; }
+  void setFps(int newFps) { fps = newFps; }
+
+  void setCameraMessage(String message, int camera_action, int fps);
 
 private:
   // Used to track desired state from Firebase database
   bool shouldBeOnState = false;
   // Used to track if there was an error sending command to camera board
   bool errorState = false;
-  // Define constant messages for on/off commands
-  static const struct_message CAMERA_ON_MESSAGE;
-  static const struct_message CAMERA_OFF_MESSAGE;
+  int fps = 5;
+  // Initialize memory to send all commands for camera control
+  camera_message cameraMessage;
 
   // ESP-NOW retry variables
   bool currentlySendingEspNowCommand = false;
   int currentRetryCount = 0;
   static constexpr int MAX_ESP_NOW_RETRIES = 5;
 
-  bool attemptSend(const struct_message &message);
+  bool attemptSend(const camera_message &message);
 };

--- a/src/devices/CameraDevice.h
+++ b/src/devices/CameraDevice.h
@@ -1,6 +1,8 @@
 #pragma once
+#include "../config/Credentials.h"
 #include "../utils/MessageTypes.h"
 #include "Device.h"
+
 #define sensor_t camera_sensor_t
 #include <esp_camera.h>
 #undef sensor_t
@@ -13,7 +15,7 @@
 
 class CameraDevice : public Device {
 public:
-  CameraDevice(const std::string &name, const uint8_t macAddress[6]);
+  CameraDevice(const std::string &name); //, const uint8_t macAddress[6]);
   void begin() override{};
   void update() override{};
   // Using override calls to start and stop streams
@@ -23,7 +25,7 @@ public:
   void applyState(JsonVariantConst desired) override;
 
 private:
-  uint8_t cameraBoardMacAddress[6];
+  // uint8_t cameraBoardMacAddress[6];
   // Define constant messages for on/off commands
   static const struct_message CAMERA_ON_MESSAGE;
   static const struct_message CAMERA_OFF_MESSAGE;

--- a/src/devices/Device.h
+++ b/src/devices/Device.h
@@ -21,7 +21,7 @@ public:
   virtual void update() = 0; // called in main loop
   virtual void turnOn() = 0;
   virtual void turnOff() = 0;
-  // Functions to handle state syncing between webpage and esp32
+  // Functions to handle state syncing between webpage and esp32 using firebase
   virtual void applyState(JsonVariantConst desired) = 0;
   virtual void reportState(JsonDocument &doc) = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,6 +98,7 @@ void loop() {
   unsigned long now = millis();
 
   firebaseApp.loop(); // Process Firebase app tasks
+  camera.update();    // Process camera state changes if any
 
   // Allow time to be accessed in the rest of the loop
   struct tm timeInfo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ Light roomLight("lights", LIGHT_PIN, TimeOfDay(0, 0),
 // firebase state with published reported states.
 // Camera streaming is handled in camera_board_main.cpp uploaded
 // to the camera board
-CameraDevice camera("camera", CAMERA_BOARD_MAC_ADDRESS);
+CameraDevice camera("camera");
 
 struct_message cameraBoardData;
 // callback that makes sure firebase state is synced after data is sent

--- a/src/utils/MessageTypes.h
+++ b/src/utils/MessageTypes.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct struct_message {
+  char message[32];
+  int camera_action;
+};

--- a/src/utils/MessageTypes.h
+++ b/src/utils/MessageTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
-struct struct_message {
+struct camera_message {
   char message[32];
   int camera_action;
+  int fps;
 };

--- a/src/utils/WiFiHelper.cpp
+++ b/src/utils/WiFiHelper.cpp
@@ -1,7 +1,7 @@
 #include "WiFiHelper.h"
 
 // Initialize static members
-struct_message WiFiHelper::myData;
+camera_message WiFiHelper::receivedData;
 
 WiFiHelper::WiFiHelper() {}
 
@@ -14,7 +14,7 @@ void WiFiHelper::defaultOnDataSent(const uint8_t *mac_addr,
 
 void WiFiHelper::defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
                                    int data_len) {
-  memcpy(&myData, data, sizeof(myData));
+  memcpy(&receivedData, data, sizeof(receivedData));
   Serial.print("Bytes received: ");
   Serial.println(data_len);
 }

--- a/src/utils/WiFiHelper.h
+++ b/src/utils/WiFiHelper.h
@@ -26,7 +26,7 @@ public:
   void maintain();
   bool getLocalTimeWithDST(struct tm &timeinfo);
 
-  static struct_message myData;
+  static camera_message receivedData;
   esp_now_peer_info_t peerInfo;
 
 private:

--- a/src/utils/WiFiHelper.h
+++ b/src/utils/WiFiHelper.h
@@ -10,9 +10,14 @@
 using SendCallback = void (*)(const uint8_t *, esp_now_send_status_t);
 using RecvCallback = void (*)(const uint8_t *, const uint8_t *, int);
 
-class WiFiUtil {
+// Class to manage WiFi, ESP-NOW, OTA, and NTP time sync
+class WiFiHelper {
 public:
-  WiFiUtil();
+  WiFiHelper();
+  static bool attemptSend(const uint8_t *mac, const uint8_t *data);
+  static void resetSendState();
+  static bool sendData(const uint8_t *mac, const uint8_t *data);
+
   static void defaultOnDataSent(const uint8_t *mac_addr,
                                 esp_now_send_status_t status);
   static void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
@@ -28,6 +33,17 @@ public:
   esp_now_peer_info_t peerInfo;
 
 private:
+  // State tracking for esp-now send retries
+  static unsigned long lastSendAttempt;
+  static int currentRetryCount;
+  static bool sendPending;
+  static const uint8_t *pendingMac;
+  static const uint8_t *pendingData;
+
+  static constexpr int ESP_NOW_RETRY_DELAY_MS = 300;
+  static constexpr int MAX_ESP_NOW_RETRIES = 10;
+  static constexpr int WIFI_RETRY_DELAY_MS = 250;
+  static constexpr int MAX_WIFI_RETRIES = 30;
   static constexpr const char *ntpServer = "pool.ntp.org";
   static constexpr const char *tzInfo = "PST8PDT,M3.2.0/2,M11.1.0/2";
 };

--- a/src/utils/WiFiHelper.h
+++ b/src/utils/WiFiHelper.h
@@ -14,9 +14,6 @@ using RecvCallback = void (*)(const uint8_t *, const uint8_t *, int);
 class WiFiHelper {
 public:
   WiFiHelper();
-  static bool attemptSend(const uint8_t *mac, const uint8_t *data);
-  static void resetSendState();
-  static bool sendData(const uint8_t *mac, const uint8_t *data);
 
   static void defaultOnDataSent(const uint8_t *mac_addr,
                                 esp_now_send_status_t status);
@@ -33,15 +30,6 @@ public:
   esp_now_peer_info_t peerInfo;
 
 private:
-  // State tracking for esp-now send retries
-  static unsigned long lastSendAttempt;
-  static int currentRetryCount;
-  static bool sendPending;
-  static const uint8_t *pendingMac;
-  static const uint8_t *pendingData;
-
-  static constexpr int ESP_NOW_RETRY_DELAY_MS = 300;
-  static constexpr int MAX_ESP_NOW_RETRIES = 10;
   static constexpr int WIFI_RETRY_DELAY_MS = 250;
   static constexpr int MAX_WIFI_RETRIES = 30;
   static constexpr const char *ntpServer = "pool.ntp.org";

--- a/src/utils/WiFiUtil.cpp
+++ b/src/utils/WiFiUtil.cpp
@@ -1,0 +1,20 @@
+#include "WiFiUtil.h"
+
+// Global variables implementation
+struct_message myData;
+esp_now_peer_info_t WiFiUtil::peerInfo;
+
+namespace WiFiUtil {
+void defaultOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
+  Serial.print("\r\nLast Packet Send Status: ");
+  Serial.println(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success"
+                                                : "Delivery Fail");
+}
+
+void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
+                       int data_len) {
+  memcpy(&myData, data, sizeof(myData));
+  Serial.print("Bytes received: ");
+  Serial.println(data_len);
+}
+} // namespace WiFiUtil

--- a/src/utils/WiFiUtil.cpp
+++ b/src/utils/WiFiUtil.cpp
@@ -1,20 +1,124 @@
 #include "WiFiUtil.h"
 
-// Global variables implementation
-struct_message myData;
-esp_now_peer_info_t WiFiUtil::peerInfo;
+// Initialize static members
+struct_message WiFiUtil::myData;
 
-namespace WiFiUtil {
-void defaultOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
+WiFiUtil::WiFiUtil() {}
+
+void WiFiUtil::defaultOnDataSent(const uint8_t *mac_addr,
+                                 esp_now_send_status_t status) {
   Serial.print("\r\nLast Packet Send Status: ");
   Serial.println(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success"
                                                 : "Delivery Fail");
 }
 
-void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
-                       int data_len) {
+void WiFiUtil::defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
+                                 int data_len) {
   memcpy(&myData, data, sizeof(myData));
   Serial.print("Bytes received: ");
   Serial.println(data_len);
 }
-} // namespace WiFiUtil
+
+void WiFiUtil::setupOTA() {
+  ArduinoOTA.onStart([]() { Serial.println("OTA Update Start"); })
+      .onEnd([]() { Serial.println("OTA Update End"); })
+      .onProgress([](unsigned int progress, unsigned int total) {
+        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+      })
+      .onError([](ota_error_t error) {
+        Serial.printf("Error[%u]: ", error);
+        if (error == OTA_AUTH_ERROR)
+          Serial.println("Auth Failed");
+        else if (error == OTA_BEGIN_ERROR)
+          Serial.println("Begin Failed");
+        else if (error == OTA_CONNECT_ERROR)
+          Serial.println("Connect Failed");
+        else if (error == OTA_RECEIVE_ERROR)
+          Serial.println("Receive Failed");
+        else if (error == OTA_END_ERROR)
+          Serial.println("End Failed");
+      });
+
+  ArduinoOTA.begin();
+  Serial.println("OTA ready. IP address: " + WiFi.localIP().toString());
+}
+
+void WiFiUtil::setupEspNow(bool isCameraBoard, RecvCallback recvCb,
+                           SendCallback sendCb) {
+  if (esp_now_init() != ESP_OK) {
+    Serial.println("Error initializing ESP-NOW");
+    return;
+  }
+
+  if (isCameraBoard) {
+    esp_now_register_recv_cb(recvCb ? recvCb : defaultOnDataRecv);
+    memcpy(peerInfo.peer_addr, MAIN_BOARD_MAC_ADDRESS, 6);
+  } else {
+    esp_now_register_send_cb(sendCb ? sendCb : defaultOnDataSent);
+    memcpy(peerInfo.peer_addr, CAMERA_BOARD_MAC_ADDRESS, 6);
+  }
+
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+    Serial.println("Failed to add peer");
+    return;
+  }
+  Serial.println("ESP-NOW initialized");
+}
+
+void WiFiUtil::connectAndSyncTime(bool shouldSetupOTA) {
+  Serial.print("Connecting to ");
+  Serial.println(WIFI_SSID);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+  uint8_t attempt = 0;
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+    if (++attempt > 60) {
+      Serial.println("\nWiFi connection failed!");
+      return;
+    }
+  }
+
+  Serial.println("\nWiFi connected!");
+  Serial.print("IP Address: ");
+  Serial.println(WiFi.localIP());
+  Serial.print("MAC Address: ");
+  Serial.println(WiFi.macAddress());
+
+  if (shouldSetupOTA) {
+    setupOTA();
+  }
+
+  configTzTime(tzInfo, ntpServer);
+
+  struct tm timeinfo;
+  while (!getLocalTime(&timeinfo)) {
+    Serial.println("Waiting for NTP time sync...");
+    delay(500);
+  }
+
+  Serial.print("Time synced: ");
+  Serial.println(asctime(&timeinfo));
+}
+
+void WiFiUtil::maintain() {
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("WiFi lost, reconnecting...");
+    WiFi.disconnect();
+    WiFi.reconnect();
+  }
+  ArduinoOTA.handle();
+}
+
+bool WiFiUtil::getLocalTimeWithDST(struct tm &timeinfo) {
+  if (!getLocalTime(&timeinfo)) {
+    Serial.println("Failed to obtain time");
+    return false;
+  }
+  return true;
+}

--- a/src/utils/WiFiUtil.h
+++ b/src/utils/WiFiUtil.h
@@ -1,23 +1,28 @@
 #pragma once
-#include "../config/Credentials.h" // Put WIFI_SSID and WIFI_PASSWORD here (git-ignored)
+#include "../config/Credentials.h"
+#include <Arduino.h> // For uint8_t and other Arduino types
 #include <ArduinoOTA.h>
 #include <WiFi.h>
 #include <esp_now.h>
-#include <time.h>
 
 // Structure example to send data
 // Must match the receiver structure
-typedef struct struct_message {
+struct struct_message {
   char message[32];
   int camera_action;
-} struct_message;
+};
 
-// Create a struct_message called myData
-struct_message myData;
+// Global variables
+extern struct_message myData;
 
 namespace WiFiUtil {
+extern esp_now_peer_info_t peerInfo;
 
-// NTP Server
+// ESP-NOW callback functions
+void defaultOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status);
+void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
+                       int data_len);
+} // namespace WiFiUtil
 constexpr const char *ntpServer = "pool.ntp.org";
 
 // Pacific Time with automatic DST rules
@@ -80,9 +85,6 @@ inline void setupEspNow(bool isCameraBoard = false,
     Serial.println("Error initializing ESP-NOW");
     return;
   }
-  // Dummy values to be updated by user
-  uint8_t MAIN_BOARD_MAC_ADDRESS[6] = {0x70, 0xB8, 0xF6, 0x5D, 0x94, 0xB4};
-  uint8_t CAMERA_BOARD_MAC_ADDRESS[6] = {0x84, 0xF7, 0x03, 0xB2, 0x4B, 0x0C};
 
   if (isCameraBoard) {
     esp_now_register_recv_cb(recvCb ? recvCb : defaultOnDataRecv);
@@ -161,5 +163,3 @@ inline bool getLocalTimeWithDST(struct tm &timeinfo) {
   }
   return true; // tm_isdst will be correct automatically
 }
-
-} // namespace WiFiUtil

--- a/src/utils/WiFiUtil.h
+++ b/src/utils/WiFiUtil.h
@@ -26,7 +26,6 @@ constexpr const char *tzInfo = "PST8PDT,M3.2.0/2,M11.1.0/2";
 // Define callback function types
 using SendCallback = void (*)(const uint8_t *, esp_now_send_status_t);
 using RecvCallback = void (*)(const uint8_t *, const uint8_t *, int);
-
 esp_now_peer_info_t peerInfo;
 
 // callback when data is sent
@@ -81,6 +80,9 @@ inline void setupEspNow(bool isCameraBoard = false,
     Serial.println("Error initializing ESP-NOW");
     return;
   }
+  // Dummy values to be updated by user
+  uint8_t MAIN_BOARD_MAC_ADDRESS[6] = {0x70, 0xB8, 0xF6, 0x5D, 0x94, 0xB4};
+  uint8_t CAMERA_BOARD_MAC_ADDRESS[6] = {0x84, 0xF7, 0x03, 0xB2, 0x4B, 0x0C};
 
   if (isCameraBoard) {
     esp_now_register_recv_cb(recvCb ? recvCb : defaultOnDataRecv);

--- a/src/utils/WiFiUtil.h
+++ b/src/utils/WiFiUtil.h
@@ -1,165 +1,33 @@
 #pragma once
 #include "../config/Credentials.h"
-#include <Arduino.h> // For uint8_t and other Arduino types
+#include "MessageTypes.h"
+#include <Arduino.h>
 #include <ArduinoOTA.h>
 #include <WiFi.h>
 #include <esp_now.h>
 
-// Structure example to send data
-// Must match the receiver structure
-struct struct_message {
-  char message[32];
-  int camera_action;
-};
-
-// Global variables
-extern struct_message myData;
-
-namespace WiFiUtil {
-extern esp_now_peer_info_t peerInfo;
-
-// ESP-NOW callback functions
-void defaultOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status);
-void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
-                       int data_len);
-} // namespace WiFiUtil
-constexpr const char *ntpServer = "pool.ntp.org";
-
-// Pacific Time with automatic DST rules
-constexpr const char *tzInfo = "PST8PDT,M3.2.0/2,M11.1.0/2";
-
 // Define callback function types
 using SendCallback = void (*)(const uint8_t *, esp_now_send_status_t);
 using RecvCallback = void (*)(const uint8_t *, const uint8_t *, int);
-esp_now_peer_info_t peerInfo;
 
-// callback when data is sent
-void defaultOnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
-  Serial.print("\r\nLast Packet Send Status:\t");
-  Serial.println(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success"
-                                                : "Delivery Fail");
-}
+class WiFiUtil {
+public:
+  WiFiUtil();
+  static void defaultOnDataSent(const uint8_t *mac_addr,
+                                esp_now_send_status_t status);
+  static void defaultOnDataRecv(const uint8_t *mac_addr, const uint8_t *data,
+                                int data_len);
+  void setupOTA();
+  void setupEspNow(bool isCameraBoard = false, RecvCallback recvCb = nullptr,
+                   SendCallback sendCb = nullptr);
+  void connectAndSyncTime(bool shouldSetupOTA = false);
+  void maintain();
+  bool getLocalTimeWithDST(struct tm &timeinfo);
 
-// callback function that will be executed when data is received
-void defaultOnDataRecv(const uint8_t *mac, const uint8_t *incomingData,
-                       int len) {
-  memcpy(&myData, incomingData, sizeof(myData));
-  Serial.print("Bytes received: ");
-  Serial.println(len);
-  Serial.print("Message: ");
-  Serial.println(myData.message);
-  Serial.print("Camera Action: ");
-  Serial.println(myData.camera_action);
-}
+  static struct_message myData;
+  esp_now_peer_info_t peerInfo;
 
-inline void setupOTA() {
-  // OTA setup
-  ArduinoOTA.onStart([]() { Serial.println("OTA Update Start"); })
-      .onEnd([]() { Serial.println("OTA Update End"); })
-      .onProgress([](unsigned int progress, unsigned int total) {
-        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-      })
-      .onError([](ota_error_t error) {
-        Serial.printf("Error[%u]: ", error);
-        if (error == OTA_AUTH_ERROR)
-          Serial.println("Auth Failed");
-        else if (error == OTA_BEGIN_ERROR)
-          Serial.println("Begin Failed");
-        else if (error == OTA_CONNECT_ERROR)
-          Serial.println("Connect Failed");
-        else if (error == OTA_RECEIVE_ERROR)
-          Serial.println("Receive Failed");
-        else if (error == OTA_END_ERROR)
-          Serial.println("End Failed");
-      });
-
-  ArduinoOTA.begin();
-  Serial.println("OTA ready. IP address: " + WiFi.localIP().toString());
-}
-
-inline void setupEspNow(bool isCameraBoard = false,
-                        RecvCallback recvCb = nullptr,
-                        SendCallback sendCb = nullptr) {
-  // Init ESP-NOW
-  if (esp_now_init() != ESP_OK) {
-    Serial.println("Error initializing ESP-NOW");
-    return;
-  }
-
-  if (isCameraBoard) {
-    esp_now_register_recv_cb(recvCb ? recvCb : defaultOnDataRecv);
-    memcpy(peerInfo.peer_addr, MAIN_BOARD_MAC_ADDRESS, 6);
-  } else {
-    esp_now_register_send_cb(sendCb ? sendCb : defaultOnDataSent);
-    memcpy(peerInfo.peer_addr, CAMERA_BOARD_MAC_ADDRESS, 6);
-  }
-
-  peerInfo.channel = 0; // pick a channel
-  peerInfo.encrypt = false;
-  if (esp_now_add_peer(&peerInfo) != ESP_OK) {
-    Serial.println("Failed to add peer");
-    return;
-  }
-}
-
-// ----- CONNECT + OTA + NTP SYNC -----
-inline void connectAndSyncTime(bool shouldSetupOTA = false) {
-  Serial.print("Connecting to ");
-  Serial.println(WIFI_SSID);
-
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-
-  uint8_t attempt = 0;
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-    Serial.print(".");
-    if (++attempt > 60) { // ~30 seconds timeout
-      Serial.println("\nWiFi connection failed!");
-      return;
-    }
-  }
-
-  Serial.println("\nWiFi connected!");
-  Serial.print("IP Address: ");
-  Serial.println(WiFi.localIP());
-  Serial.print("MAC Address: ");
-  Serial.println(WiFi.macAddress());
-
-  // Setup OTA - for wireless updates
-  if (shouldSetupOTA) {
-    setupOTA();
-  }
-
-  // Set timezone and start NTP sync
-  configTzTime(tzInfo, ntpServer);
-
-  // Wait for time sync
-  struct tm timeinfo;
-  while (!getLocalTime(&timeinfo)) {
-    Serial.println("Waiting for NTP time sync...");
-    delay(500);
-  }
-
-  Serial.print("Time synced: ");
-  Serial.println(asctime(&timeinfo));
-}
-
-// ----- AUTO-RECONNECT -----
-inline void maintain() {
-  if (WiFi.status() != WL_CONNECTED) {
-    Serial.println("WiFi lost, reconnecting...");
-    WiFi.disconnect();
-    WiFi.reconnect();
-  }
-  ArduinoOTA.handle(); // Keep checking for OTA updates
-}
-
-// ----- GET LOCAL TIME -----
-inline bool getLocalTimeWithDST(struct tm &timeinfo) {
-  if (!getLocalTime(&timeinfo)) {
-    Serial.println("Failed to obtain time");
-    return false;
-  }
-  return true; // tm_isdst will be correct automatically
-}
+private:
+  static constexpr const char *ntpServer = "pool.ntp.org";
+  static constexpr const char *tzInfo = "PST8PDT,M3.2.0/2,M11.1.0/2";
+};


### PR DESCRIPTION
I needed the camera board to be a sperate esp-32 device since the camera cable being very long caused signal issues making it unusable. Now I can route long power cables to the esp-32-cam device and have the camera be integrated with the board to avoid any distance issues and initiate streaming and settings changes with esp-now.